### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.7
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prepare - Checkout
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@v4.1.7
 
       - name: Prepare - Compose
         uses: php-actions/composer@v6
@@ -18,7 +18,7 @@ jobs:
         working-directory: tests
 
       - name: Test - RUN
-        uses: php-actions/phpunit@master
+        uses: php-actions/phpunit@v4
         env: 
           CONFIG__WAIT: 60
           CONFIG__SERVER__URL: http://localhost:8080


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[php-actions/phpunit](https://github.com/php-actions/phpunit)** published a new release **[v4](https://github.com/php-actions/phpunit/releases/tag/v4)** on 2024-04-25T16:25:05Z
